### PR TITLE
Bump API version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     env:
-      API_VERSION: 35
+      API_VERSION: 36
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
API_VERSION has been bumped to 36 (TAC commit fd3df23a).