### PR TITLE
Bump to static API version 36 #4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     env:
-      API_VERSION: 35
+      API_VERSION: 36
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Static API version 36 in use since version 3.8.7 of TousAntiCovid Android: https://gitlab.inria.fr/stopcovid19/stopcovid-android/-/blame/master/coreui/src/main/java/com/lunabeestudio/stopcovid/coreui/ConfigConstant.kt#L15