### PR TITLE
Bump API version

### DIFF
--- a/download_tac.py
+++ b/download_tac.py
@@ -9,7 +9,7 @@ from proto import hashes_pb2
 
 BASE_URL="https://app.tousanticovid.gouv.fr/"
 STATIC_BASE_URL="https://app-static.tousanticovid.gouv.fr/"
-VERSIONED_PATH="json/version-37/"
+VERSIONED_PATH="json/version-40/"
 VERSIONED_SERVER_URL=STATIC_BASE_URL+VERSIONED_PATH
 
 MAINTENANCE_FOLDER="maintenance/"


### PR DESCRIPTION
API version is now 40.
The new config file is available at https://app-static.tousanticovid.gouv.fr/json/version-40/Config/config.json (as expected) but I didn't check if other stuff has moved...